### PR TITLE
Risolto bug Ricolorazione

### DIFF
--- a/LTN/src/main/kotlin/com/example/ltn/LTNController.kt
+++ b/LTN/src/main/kotlin/com/example/ltn/LTNController.kt
@@ -1,6 +1,5 @@
 package com.example.ltn
 
-import javafx.beans.binding.Bindings
 import javafx.collections.FXCollections
 import javafx.collections.ObservableList
 import javafx.fxml.FXML
@@ -10,16 +9,12 @@ import javafx.scene.input.KeyCode
 import javafx.scene.input.KeyEvent
 import javafx.scene.input.MouseButton
 import javafx.scene.input.MouseEvent
-import javafx.scene.layout.VBox
 import com.example.ui.BarredText
 import com.example.ui.MagicScrollPanel
-import com.sun.javafx.tk.Toolkit
-import javafx.application.Platform
-import javafx.scene.layout.Background
-import javafx.scene.paint.Color
+import com.example.ui.MagicVBox
 
 class LTNController {
-    @FXML private lateinit var box:VBox
+    @FXML private lateinit var box: MagicVBox
     @FXML private lateinit var textField: TextField
     @FXML private lateinit var scroll: MagicScrollPanel
 
@@ -27,8 +22,7 @@ class LTNController {
 
     @FXML
     fun initialize() {
-        Bindings.bindContentBidirectional(boxContent, box.children)     // binds the list to VBox
-
+        box.bindContent(boxContent)
     }
 
     @FXML
@@ -86,7 +80,7 @@ class LTNController {
             MouseButton.SECONDARY -> {  // removing elem
                 boxContent.remove(event.source)
 
-                BarredText.recolor(boxContent)
+                box.updateBgs()
 
                 println("\tRemoved ${event.source}")
             }

--- a/LTN/src/main/kotlin/com/example/ltn/LTNController.kt
+++ b/LTN/src/main/kotlin/com/example/ltn/LTNController.kt
@@ -13,6 +13,10 @@ import javafx.scene.input.MouseEvent
 import javafx.scene.layout.VBox
 import com.example.ui.BarredText
 import com.example.ui.MagicScrollPanel
+import com.sun.javafx.tk.Toolkit
+import javafx.application.Platform
+import javafx.scene.layout.Background
+import javafx.scene.paint.Color
 
 class LTNController {
     @FXML private lateinit var box:VBox
@@ -78,6 +82,7 @@ class LTNController {
 
                 println("\tSett isBarred to ${source.isBarred} on $source")
             }
+
             MouseButton.SECONDARY -> {  // removing elem
                 boxContent.remove(event.source)
 
@@ -85,6 +90,7 @@ class LTNController {
 
                 println("\tRemoved ${event.source}")
             }
+
             else -> println("\tDo noting: ${event.button}")
         }
 

--- a/LTN/src/main/kotlin/com/example/ltn/LTNController.kt
+++ b/LTN/src/main/kotlin/com/example/ltn/LTNController.kt
@@ -81,7 +81,7 @@ class LTNController {
             MouseButton.SECONDARY -> {  // removing elem
                 boxContent.remove(event.source)
 
-                BarredText.recolor(boxContent as List<BarredText>)
+                BarredText.recolor(boxContent)
 
                 println("\tRemoved ${event.source}")
             }

--- a/LTN/src/main/kotlin/com/example/ui/BarredText.kt
+++ b/LTN/src/main/kotlin/com/example/ui/BarredText.kt
@@ -37,9 +37,9 @@ class BarredText (text:String): StackPane() {
     var bg: String = ""
         set(value) {
             field = value
-            this.style = "-fx-background-color: ${value};"
-        }
-
+            this.style += "-fx-background-color: ${value};"     // this should prevent to reset all the css props
+        }                                                       // when a bg is set. Seems that adding same css prop
+                                                                // rewrite the existing one without touching the others
 
     companion object Colorator {
         private var conta = 0
@@ -65,7 +65,7 @@ class BarredText (text:String): StackPane() {
     }
 
     init {
-        bg = initBg()
+        bg = initBg()           // set initial bg
 
         line.strokeWidth = 1.5  // set line stroke
 

--- a/LTN/src/main/kotlin/com/example/ui/BarredText.kt
+++ b/LTN/src/main/kotlin/com/example/ui/BarredText.kt
@@ -1,5 +1,7 @@
 package com.example.ui
 
+import javafx.collections.ObservableList
+import javafx.scene.Node
 import javafx.scene.layout.StackPane
 import javafx.scene.control.Label
 import javafx.scene.layout.Pane
@@ -66,11 +68,11 @@ class BarredText (text:String): StackPane() {
                 odd
         }
 
-        fun recolor(list: List<BarredText>) {
+        fun recolor(list: ObservableList<Node>) {
             conta = 0
 
             for (elem in list) {
-                elem.bg = initBg()
+                (elem as BarredText).bg = initBg()
             }
 
         }

--- a/LTN/src/main/kotlin/com/example/ui/BarredText.kt
+++ b/LTN/src/main/kotlin/com/example/ui/BarredText.kt
@@ -1,7 +1,5 @@
 package com.example.ui
 
-import javafx.collections.ObservableList
-import javafx.scene.Node
 import javafx.scene.layout.StackPane
 import javafx.scene.control.Label
 import javafx.scene.layout.Pane
@@ -41,32 +39,7 @@ class BarredText (text:String): StackPane() {
         }                                                       // when a bg is set. Seems that adding same css prop
                                                                 // rewrite the existing one without touching the others
 
-    companion object Colorator {
-        private var conta = 0
-        //const val odd = "pane_odd"
-        //const val even = "pane_even"
-
-        private fun initBg(): String {
-            conta += 1
-
-            return if (conta %2 == 0)
-                "white"
-            else
-                "lightgray"
-        }
-
-        fun recolor(list: ObservableList<Node>) {
-            conta = 0
-
-            for (elem in list) {
-                (elem as BarredText).bg = initBg()
-            }
-        }
-    }
-
     init {
-        bg = initBg()           // set initial bg
-
         line.strokeWidth = 1.5  // set line stroke
 
         // binds the line to the label

--- a/LTN/src/main/kotlin/com/example/ui/BarredText.kt
+++ b/LTN/src/main/kotlin/com/example/ui/BarredText.kt
@@ -33,39 +33,26 @@ class BarredText (text:String): StackPane() {
             label.text = value
         }
 
+    // set the bg color
     var bg: String = ""
         set(value) {
             field = value
-            when (value) {
-                odd -> {
-                    panel.styleClass.remove(even)
-                    panel.styleClass.add(odd)
-                }
-                even -> {
-                    panel.styleClass.remove(odd)
-                    panel.styleClass.add(even)
-                }
-                else -> {
-                    panel.styleClass.add(value)
-                }
-            }
-
-
+            this.style = "-fx-background-color: ${value};"
         }
 
 
     companion object Colorator {
         private var conta = 0
-        const val odd = "pane_odd"
-        const val even = "pane_even"
+        //const val odd = "pane_odd"
+        //const val even = "pane_even"
 
         private fun initBg(): String {
             conta += 1
 
             return if (conta %2 == 0)
-                even
+                "white"
             else
-                odd
+                "lightgray"
         }
 
         fun recolor(list: ObservableList<Node>) {
@@ -74,7 +61,6 @@ class BarredText (text:String): StackPane() {
             for (elem in list) {
                 (elem as BarredText).bg = initBg()
             }
-
         }
     }
 

--- a/LTN/src/main/kotlin/com/example/ui/MagicVBox.kt
+++ b/LTN/src/main/kotlin/com/example/ui/MagicVBox.kt
@@ -1,0 +1,46 @@
+package com.example.ui
+
+import javafx.beans.binding.Bindings
+import javafx.collections.ListChangeListener
+import javafx.collections.ObservableList
+import javafx.scene.Node
+import javafx.scene.layout.VBox
+
+class MagicVBox: VBox() {
+
+    init {
+        // when a new elem is added, choose the right bg
+        this.children.addListener { c: ListChangeListener.Change<out Node> ->
+            while (c.next()) {
+                if (c.wasAdded()) {
+                    // set initial node bg
+                    val index = c.from
+                    val node = c.list[index]
+
+                    initBg(index, node)
+                }
+            }
+        }
+    }
+
+    fun bindContent(bindList: ObservableList<Node>) {
+        Bindings.bindContentBidirectional(bindList, this.children)
+    }
+
+    private fun initBg(index: Int, node: Node) {
+        val elem = node as BarredText
+
+        if (index%2 == 0)
+            elem.bg = "lightgray"
+        else
+            elem.bg = "white"
+    }
+
+    fun updateBgs() {
+        val nodes = this.children
+
+        nodes.forEachIndexed { i, node ->
+            initBg(i, node)
+        }
+    }
+}

--- a/LTN/src/main/kotlin/com/example/ui/MagicVBox.kt
+++ b/LTN/src/main/kotlin/com/example/ui/MagicVBox.kt
@@ -23,10 +23,25 @@ class MagicVBox: VBox() {
         }
     }
 
+    /**
+     * Binds the [MagicVBox.children] list with the given [bindList] list.
+     *
+     * @param bindList List with the children nodes.
+     */
     fun bindContent(bindList: ObservableList<Node>) {
         Bindings.bindContentBidirectional(bindList, this.children)
     }
 
+    /**
+     * Choose the right bg for the node.
+     * Used to set the bg for new added node.
+     * For now set the bg for the even and odd children:
+     *  - if children is in an Odd position: bg = white
+     *  - else (means children in Even position): bg = lightgray
+     *
+     * @param index Index of the node in the list
+     * @param node The new node
+     */
     private fun initBg(index: Int, node: Node) {
         val elem = node as BarredText
 
@@ -36,6 +51,10 @@ class MagicVBox: VBox() {
             elem.bg = "white"
     }
 
+    /**
+     * Update all the children bgs.
+     * Used when a child is removed and bgs needs to be updated
+     */
     fun updateBgs() {
         val nodes = this.children
 

--- a/LTN/src/main/resources/com/example/ltn/ltn-view.fxml
+++ b/LTN/src/main/resources/com/example/ltn/ltn-view.fxml
@@ -10,6 +10,7 @@
 <?import javafx.scene.control.ScrollPane?>
 <?import org.kordamp.bootstrapfx.scene.layout.Panel?>
 <?import com.example.ui.MagicScrollPanel?>
+<?import com.example.ui.MagicVBox?>
 <VBox alignment="TOP_CENTER" spacing="20.0" xmlns:fx="http://javafx.com/fxml"
       fx:controller="com.example.ltn.LTNController" stylesheets="@style.css">
     <padding>
@@ -17,7 +18,7 @@
     </padding>
 
     <MagicScrollPanel fx:id="scroll" hbarPolicy="NEVER" fitToWidth="true">
-            <VBox fx:id="box" alignment="TOP_CENTER" xmlns:fx="http://javafx.com/fxml"/>
+            <MagicVBox fx:id="box" alignment="TOP_CENTER" xmlns:fx="http://javafx.com/fxml"/>
     </MagicScrollPanel>
     <TextField fx:id="textField" onKeyPressed="#onTextTyped"/>
 

--- a/LTN/src/main/resources/com/example/ltn/ltn-view.fxml
+++ b/LTN/src/main/resources/com/example/ltn/ltn-view.fxml
@@ -1,16 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.VBox?>
-
-<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.TextField?>
-
-<?import javafx.scene.control.ScrollPane?>
-<?import org.kordamp.bootstrapfx.scene.layout.Panel?>
 <?import com.example.ui.MagicScrollPanel?>
 <?import com.example.ui.MagicVBox?>
+
 <VBox alignment="TOP_CENTER" spacing="20.0" xmlns:fx="http://javafx.com/fxml"
       fx:controller="com.example.ltn.LTNController" stylesheets="@style.css">
     <padding>
@@ -21,5 +16,4 @@
             <MagicVBox fx:id="box" alignment="TOP_CENTER" xmlns:fx="http://javafx.com/fxml"/>
     </MagicScrollPanel>
     <TextField fx:id="textField" onKeyPressed="#onTextTyped"/>
-
 </VBox>

--- a/LTN/src/main/resources/com/example/ltn/style.css
+++ b/LTN/src/main/resources/com/example/ltn/style.css
@@ -2,11 +2,11 @@
 	-fx-font-size: 16px;
 }
 
-.pane_odd {
+.pane_odd { /*useless for now*/
     -fx-background-color: lightgray;
 }
 
-.pane_even {
+.pane_even { /*useless for now*/
     -fx-background-color: white;
 }
 


### PR DESCRIPTION
Risolta issue #1 .

Ora la scelta del colore di bg viene gestita da un classe apposita MagicVBox (un VBox modificato).
Questa classe estende VBox e fa si che quando un nuovo elemento viene aggiunto sceglie automaticamente il colore da assegnare:

   - se si trova in posizione (della listi di tutti i nodi di MagicVBox) `pari` il suo bg sarà `lightgray`
   - se si trova in posizione `dispari` il suo bg sarà `white`

Questa nuova classe si fa anche carico di gestire la ricolorazione dei suoi nodi:
   
   - Quando un nodo viene rimosso, va aggiornato il colore di bg degli altri nodi. Questa classe lo fa come descritto sopra, guarda la posizione nella lista e riaggiorna il loro bg.

<br>

Diminuita notevolmente la dimensione e i compiti della classe `BarredText`. Ora questa si occupa solo della gestione dell'elemento grafico `Texto con Barra`. La gestione  del bg è stata cambiata come segue:

   - a quanto pare, usare le classi css (quindi aggiungere o togliere classi) causava il bug #1, quindi non si usano più le classi css ma si aggiungono direttamente proprietà css.
   - a quanto pare aggiungere la stessa proprietà css (ma con valori diversi: e.g. bg rosso e bg nero) ad un elemento non causa alcun problema e l'ultima aggiunta  sovrascrive le altre dello stesso tipo. 